### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+job:
+ include:
+  if: brach = master
+
 language: python
 before_install:
  - sudo apt update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 job:
  include:
-  if: brach = master
+  if: branch = master
 
 language: python
 before_install:


### PR DESCRIPTION
En travis se pueden triggerear 2 tipos de builds: Los builds por PR y los builds por push a cualquier rama.

Con este filtro yo hago que travis solamente haga los builds de PR que se van a mergear a master y que haga build cuando se haya mergeado el PR.

Antes cuando yo creaba un PR, se hacian automaticamente 3 builds uno por el PR a master, otro por pushear a la rama del PR y otro cuando se mergea el PR.